### PR TITLE
feat: replace `AppDir` with `LogDir`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Tauri Programme within The Commons Conservancy" ]
 edition = "2018"
 
 [dependencies]
-tauri = { git = "https://github.com/tauri-apps/tauri", commit = "acbb3ae7bb0165846b9456aea103269f027fc548" }
+tauri = { git = "https://github.com/tauri-apps/tauri", branch = "next" }
 serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Tauri Programme within The Commons Conservancy" ]
 edition = "2018"
 
 [dependencies]
-tauri = "1.0.0-beta.8"
+tauri = { git = "https://github.com/tauri-apps/tauri", commit = "acbb3ae7bb0165846b9456aea103269f027fc548" }
 serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
                         .into()
                 }
                 LogTarget::LogDir => {
-                    let path = tauri::api::path::log_dir(&app.config()).unwrap();
+                    let path = app.path_resolver().log_dir().unwrap();
                     if !path.exists() {
                         fs::create_dir_all(&path).unwrap();
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,8 @@ pub enum LogTarget {
     Stderr,
     /// Log to the specified folder.
     Folder(PathBuf),
-    /// Log to the specified folder, relative to the app cache directory.
-    AppDir(PathBuf),
+    /// Log to the OS appropriate log folder.
+    LogDir,
     /// Emit an event to the webview (`log://log`).
     Webview,
 }
@@ -190,8 +190,8 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
                     fern::log_file(get_log_file_path(&config, &path, &self.rotation_strategy)?)?
                         .into()
                 }
-                LogTarget::AppDir(path) => {
-                    let path = app.path_resolver().app_dir().unwrap().join(path);
+                LogTarget::LogDir => {
+                    let path = tauri::api::path::log_dir(&app.config()).unwrap();
                     if !path.exists() {
                         fs::create_dir_all(&path).unwrap();
                     }


### PR DESCRIPTION
Replaces `AppDir` with `LogDir` closing tauri-apps/plugins-workspace#172.
This PR should only be merged once tauri-apps/tauri#2736 and tauri-apps/tauri#2756.