### PR TITLE
fix(package.json): add exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,18 @@
   "description": "Tauri Plugin for logging",
   "browser": "webview-dist/index.min.js",
   "module": "webview-dist/index.mjs",
-  "types": "webview-dist/index.d.ts", 
+  "types": "webview-dist/index.d.ts",
   "private": "true",
-   "files": [
-     "webview-dist"
-   ],
+  "files": [
+    "webview-dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./webview-dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "rollup -c ./webview-src/rollup.config.js",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
add the exports attribute to the package.json to let modern versions of node and ESM-first frameworks (vite and vitest) load the appropiate package file.