### PR TITLE
fix: use correct app name

### DIFF
--- a/.changes/use-app-name.md
+++ b/.changes/use-app-name.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin-log": patch
+---
+
+Use the name from `Cargo.toml` to name the logfile.

--- a/.changes/use-app-name.md
+++ b/.changes/use-app-name.md
@@ -2,4 +2,4 @@
 "tauri-plugin-log": patch
 ---
 
-Use the name from `Cargo.toml` to name the logfile.
+Use the name from `package > productName` or `Cargo.toml` to name the logfile.

--- a/examples/cra/src-tauri/Cargo.toml
+++ b/examples/cra/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "cra-app"
 version = "0.1.0"
 description = "A Tauri App"
 authors = [ "Tauri Programme within The Commons Conservancy" ]

--- a/examples/svelte-app/src-tauri/Cargo.lock
+++ b/examples/svelte-app/src-tauri/Cargo.lock
@@ -39,17 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-log",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +2715,17 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "svelte-app"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-log",
+]
 
 [[package]]
 name = "syn"

--- a/examples/svelte-app/src-tauri/Cargo.toml
+++ b/examples/svelte-app/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "app"
+name = "svelte-app"
 version = "0.1.0"
 description = "A Tauri App"
 authors = [ "Tauri Programme within The Commons Conservancy" ]
 repository = ""
-default-run = "app"
+default-run = "svelte-app"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,8 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
     app_handle: &AppHandle<R>,
     _config: serde_json::Value,
   ) -> PluginResult<()> {
+    let app_name = &app_handle.package_info().name;
+
     let mut dispatch = self
       .dispatch
       .take()
@@ -262,6 +264,7 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
 
           fern::log_file(get_log_file_path(
             &path,
+            app_name,
             &self.rotation_strategy,
             self.max_file_size,
           )?)?
@@ -275,6 +278,7 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
 
           fern::log_file(get_log_file_path(
             &path,
+            app_name,
             &self.rotation_strategy,
             self.max_file_size,
           )?)?
@@ -312,11 +316,10 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
 
 fn get_log_file_path(
   dir: &impl AsRef<Path>,
+  app_name: &str,
   rotation_strategy: &RotationStrategy,
   max_file_size: u128,
 ) -> PluginResult<PathBuf> {
-  let app_name = env!("CARGO_PKG_NAME");
-
   let path = dir.as_ref().join(format!("{}.log", app_name));
 
   if path.exists() {


### PR DESCRIPTION
Currently the `env!` macro is used to name the logfile, which is stupid bc it will always result in logfiles names `tauri-plugin-log.log`.

This PR uses the crates names from `Cargo.toml` instead.
Edit: Or not? Apparently `AppHandle::package_info()` gives still gives you the name from `tauri.conf.json` 🤔 