### PR TITLE
fix: deadlock on window close

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use log::{debug, error, info, trace, warn, LevelFilter, Record};
 use serde::Serialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::borrow::Cow;
-use std::sync::Mutex;
 use std::{
   fmt::Arguments,
   fs::{self, File},
@@ -287,12 +286,10 @@ impl<R: Runtime> Plugin<R> for Logger<R> {
           .into()
         }
         LogTarget::Webview => {
-          let app_handle = Mutex::new(app_handle.clone());
+          let app_handle = app_handle.clone();
 
           fern::Output::call(move |record| {
             app_handle
-              .lock()
-              .unwrap()
               .emit_all(
                 "log://log",
                 RecordPayload {


### PR DESCRIPTION
This PR fixes a mutex deadlock that occured in rather bizarre circumstances:

1. The plugin was configured with `LogTarget::WebView` (so the mutex codepath was hit) and `LogLevel` was `Trace` (the event that triggered the lock was `Trace`)
2. A second window was open
3. The second window was closed
4. (I assume) The core tries to lock the app to drop the window, while the plugin holds the lock to emit an event to the Frontend.

I think this reasoning checks out? Anyway I realized we don't need this lock to begin with, since we can just clone the AppHandle. Not sure why I put it there at all honestly.