### PR TITLE
Use datetime for log filename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,8 +292,9 @@ fn get_log_file_path(
       match rotation_strategy {
         RotationStrategy::KeepAll => {
           let to = dir.as_ref().join(format!(
-            "{}.log",
-            chrono::Local::now().format("app_%Y-%m-%d_%H-%M-%S")
+            "{}_{}.log",
+            app_name,
+            chrono::Local::now().format("%Y-%m-%d_%H-%M-%S")
           ));
           if to.is_file() {
             // designated rotated log file name already exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,10 @@ fn get_log_file_path(
             // designated rotated log file name already exists
             // highly unlikely but defensively handle anyway by adding .bak to filename
             let mut to_bak = to.clone();
-            to_bak.set_file_name(format!("{}.bak", to_bak.file_name().unwrap().to_string_lossy()));
+            to_bak.set_file_name(format!(
+              "{}.bak",
+              to_bak.file_name().unwrap().to_string_lossy()
+            ));
             fs::rename(&to, to_bak)?;
           }
           fs::rename(&path, to)?;


### PR DESCRIPTION
This avoids issues where a twice-in-a-day rotation overwrites older logs.
Fixes tauri-apps/plugins-workspace#167.