### PR TITLE
Document how to log from rust code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more details and usage see [the example app](examples/svelte-app). Please no
 
 ### RUST
 `src-tauri/Cargo.toml`
-```yaml
+```toml
 [dependencies.tauri-plugin-log]
 git = "https://github.com/tauri-apps/tauri-plugin-log"
 tag = "v0.1.0"
@@ -50,6 +50,14 @@ fn main() {
         .run();
 }
 ```
+
+To log from rust code, add the `log` crate to your `cargo.toml`:
+```toml
+[dependencies]
+log = "^0.4"
+```
+Now, you can use the macros provided by the `log` crate to log messages from your backend.
+See the [docs](https://docs.rs/log/latest) for more details.
 
 ### WEBVIEW
 


### PR DESCRIPTION
It took me way too long to notice that this plugin also serves as a backend for the `log` crate.
This should be displayed more prominently and documented in the readme.